### PR TITLE
Fix: 지난 콘티 클릭 시 내용 불러오기 기능 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,7 +251,9 @@
                             <div class="history-text">${item.text}</div>
                         `;
                         li.onclick = () => {
-                            // ... (기존 로직 동일)
+                            document.getElementById('setlist-title').value = item.title || "";
+                            document.getElementById('song-input').value = item.text || "";
+                            closeHistoryModal();
                         };
                         container.appendChild(li);
                     });


### PR DESCRIPTION
historyModal 아이템의 onclick 핸들러가 빈 주석으로 남아있어
터치/클릭해도 동작하지 않던 문제 수정.
클릭 시 제목과 곡 목록을 각 입력창에 채우고 모달을 닫도록 구현.