### PR TITLE
feat: Open Graph 메타태그 및 링크 미리보기 이미지 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,22 @@
     <meta name="theme-color" content="#0070f3">
     <link rel="manifest" href="manifest.json">
 
+    <!-- Open Graph (카카오톡, 슬랙, 디스코드 등 링크 미리보기) -->
+    <meta property="og:type"        content="website">
+    <meta property="og:url"         content="https://score-fetcher.vercel.app/">
+    <meta property="og:title"       content="찬양 악보 매니저">
+    <meta property="og:description" content="예배 콘티 관리 · 악보 뷰어 · 실시간 푸시 알림">
+    <meta property="og:image"       content="https://score-fetcher.vercel.app/og-image.svg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:locale"      content="ko_KR">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card"        content="summary_large_image">
+    <meta name="twitter:title"       content="찬양 악보 매니저">
+    <meta name="twitter:description" content="예배 콘티 관리 · 악보 뷰어 · 실시간 푸시 알림">
+    <meta name="twitter:image"       content="https://score-fetcher.vercel.app/og-image.svg">
+
     <!-- Firebase SDK (Cloud Messaging 푸시 알림용) -->
     <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-messaging-compat.js"></script>

--- a/og-image.svg
+++ b/og-image.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#16213e"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0070f3"/>
+      <stop offset="100%" style="stop-color:#7928ca"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- 배경 -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- 배경 장식 원 -->
+  <circle cx="1050" cy="150" r="200" fill="#0070f3" opacity="0.07"/>
+  <circle cx="150" cy="500" r="160" fill="#7928ca" opacity="0.07"/>
+
+  <!-- 상단 악센트 바 -->
+  <rect x="80" y="80" width="120" height="6" rx="3" fill="url(#accent)"/>
+
+  <!-- 음표 아이콘 영역 -->
+  <text x="80" y="230" font-size="90" font-family="Arial, sans-serif" fill="white" opacity="0.15">🎵</text>
+
+  <!-- 메인 타이틀 -->
+  <text x="80" y="310" font-family="'Apple SD Gothic Neo', 'Noto Sans KR', Arial, sans-serif"
+        font-size="72" font-weight="700" fill="white" filter="url(#glow)">찬양 악보 매니저</text>
+
+  <!-- 서브타이틀 -->
+  <text x="84" y="375" font-family="'Apple SD Gothic Neo', 'Noto Sans KR', Arial, sans-serif"
+        font-size="34" font-weight="400" fill="#94a3b8">예배 콘티 · 악보 뷰어 · 실시간 공유</text>
+
+  <!-- 구분선 -->
+  <rect x="80" y="415" width="1040" height="1" fill="#334155"/>
+
+  <!-- 기능 태그 -->
+  <rect x="80" y="447" width="160" height="44" rx="22" fill="#0070f3" opacity="0.2"/>
+  <text x="160" y="475" text-anchor="middle" font-family="'Apple SD Gothic Neo', 'Noto Sans KR', Arial, sans-serif"
+        font-size="22" fill="#60a5fa">📖 전체 리스트</text>
+
+  <rect x="260" y="447" width="160" height="44" rx="22" fill="#7928ca" opacity="0.2"/>
+  <text x="340" y="475" text-anchor="middle" font-family="'Apple SD Gothic Neo', 'Noto Sans KR', Arial, sans-serif"
+        font-size="22" fill="#c084fc">🕒 지난 콘티</text>
+
+  <rect x="440" y="447" width="160" height="44" rx="22" fill="#059669" opacity="0.2"/>
+  <text x="520" y="475" text-anchor="middle" font-family="'Apple SD Gothic Neo', 'Noto Sans KR', Arial, sans-serif"
+        font-size="22" fill="#34d399">🔔 푸시 알림</text>
+
+  <rect x="620" y="447" width="160" height="44" rx="22" fill="#d97706" opacity="0.2"/>
+  <text x="700" y="475" text-anchor="middle" font-family="'Apple SD Gothic Neo', 'Noto Sans KR', Arial, sans-serif"
+        font-size="22" fill="#fbbf24">💡 화면 유지</text>
+
+  <!-- URL 표시 -->
+  <text x="80" y="565" font-family="'SF Mono', 'Consolas', monospace"
+        font-size="26" fill="#475569">score-fetcher.vercel.app</text>
+
+  <!-- 우측 장식 -->
+  <text x="1060" y="340" text-anchor="middle" font-size="140" font-family="Arial"
+        fill="white" opacity="0.06">♪</text>
+</svg>


### PR DESCRIPTION
- og-image.svg 생성 (1200x630, 다크 그라디언트 디자인)
- OG 메타태그 추가 (og:title, description, image 등)
- Twitter Card 메타태그 추가
- 카카오톡, 슬랙, 디스코드 등 링크 공유 시 미리보기 카드 표시

https://claude.ai/code/session_01XTSPpZiBjQn5f35g93aBy4