### PR TITLE
fix: 찬양 목록 정렬 버튼 화면 벗어남 수정 (#47)

### DIFF
--- a/style.css
+++ b/style.css
@@ -246,7 +246,7 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 .btn-close { background: none; border: none; color: rgba(255,255,255,0.65); font-size: 24px; cursor: pointer; }
 .modal-search { padding: 12px 16px; background: var(--surface-low); display: flex; align-items: center; gap: 10px; }
 .modal-search input {
-    flex: 1; padding: 10px 0;
+    flex: 1; min-width: 0; padding: 10px 0;
     border: none; border-bottom: 2px solid var(--outline-variant);
     border-radius: 0; outline: none;
     font-family: 'Inter', -apple-system, sans-serif;


### PR DESCRIPTION
## 원인
`.modal-search` flex 레이아웃에서 `<input>`의 브라우저 기본 `min-width`(~200px)가 flex shrink를 막아, 버튼 텍스트가 `🔥 많이 부른 순` / `📉 적게 부른 순`으로 바뀔 때 버튼이 모달 오른쪽 밖으로 밀려남.

## 수정
`style.css` — `.modal-search input`에 `min-width: 0` 추가

```css
.modal-search input {
    flex: 1; min-width: 0; /* 추가 */
    ...
}
```

`min-width: 0`으로 input이 flex 컨테이너 안에서 정상적으로 수축하면서 버튼 공간을 확보.

## 변경 파일
- `style.css` — 1줄 수정

Closes #47