### PR TITLE
feat: 폰 가로모드 분할 뷰 지원 (#48)

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -17,9 +17,9 @@ function resetAll() {
     document.getElementById('app-layout').classList.remove('ls-active');
 }
 
-function isTabletLandscape() { 
-    // 최소 너비 768px 이상이면서 가로가 세로보다 길 때만 가로 레이아웃 적용
-    return window.innerWidth >= 768 && window.innerWidth > window.innerHeight; 
+function isTabletLandscape() {
+    // 최소 너비 480px 이상이면서 가로가 세로보다 길 때만 가로 레이아웃 적용 (폰 포함)
+    return window.innerWidth >= 480 && window.innerWidth > window.innerHeight;
 }
 
 // Canvas 드로잉 유틸

--- a/style.css
+++ b/style.css
@@ -39,8 +39,8 @@ body {
     transition: max-width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* 태블릿/데스크탑 가로 모드일 때만 전체 너비 사용 */
-@media (min-width: 768px) and (orientation: landscape) {
+/* 가로 모드일 때 전체 너비 사용 (폰 포함, 480px+) */
+@media (min-width: 480px) and (orientation: landscape) {
     body { max-width: 100%; box-shadow: none; }
 }
 
@@ -526,7 +526,7 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
 #ls-sheet-title { font-size: 17px; font-weight: 800; max-width: 60%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* ─── Landscape / Tablet Mode 전용 (가로 모드일 때만 활성화) ─── */
-@media (min-width: 768px) and (orientation: landscape) {
+@media (min-width: 480px) and (orientation: landscape) {
     html { background-color: var(--primary); }
     body { max-width: 100%; border-radius: 0; box-shadow: none; }
     main {
@@ -627,8 +627,8 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
     }
 }
 
-/* ─── 태블릿 가로 ls-active: 헤더 숨기고 전체화면 ─── */
-@media (min-width: 768px) and (orientation: landscape) {
+/* ─── 가로 ls-active: 헤더 숨기고 전체화면 (폰 포함) ─── */
+@media (min-width: 480px) and (orientation: landscape) {
     body:has(.app-layout.ls-active) header { display: none; }
     body:has(.app-layout.ls-active) main   { padding-top: 10px; }
 }


### PR DESCRIPTION
## 변경 내용
가로 모드 분할 뷰 진입 기준을 **768px → 480px**로 낮춰 일반 스마트폰에서도 가로 전환 시 분할 뷰어가 활성화되도록 수정.

## 기존 vs 변경

| 항목 | 기존 | 변경 |
|------|------|------|
| CSS 미디어 쿼리 | `min-width: 768px` | `min-width: 480px` |
| JS `isTabletLandscape()` | `innerWidth >= 768` | `innerWidth >= 480` |

## 커버되는 기기 (landscape 너비 기준)
| 기기 | 가로 너비 | 지원 여부 |
|------|-----------|-----------|
| iPhone SE (3rd gen) | ~667px | ✅ |
| 갤럭시 A시리즈 | 640px+ | ✅ |
| 갤럭시 S시리즈 | 800px+ | ✅ |
| iPhone 14/15 | 844px+ | ✅ |
| 480px 미만 (구형 소형기기) | <480px | ❌ (제외) |

## 변경 파일
- `style.css` — `@media landscape` 3곳 수정
- `js/utils.js` — `isTabletLandscape()` 기준 수정

Closes #48