### PR TITLE
fix: 찬양 목록 정렬 버튼 화면 이탈 수정 (Closes #47)

### DIFF
--- a/js/song-list.js
+++ b/js/song-list.js
@@ -7,7 +7,7 @@ let _sortMode = 'num';  // 'num' | 'freq-desc' | 'freq-asc'
 function cycleSortMode() {
     const modes = ['num', 'freq-desc', 'freq-asc'];
     _sortMode = modes[(modes.indexOf(_sortMode) + 1) % modes.length];
-    const labels = { 'num': '🔢 번호순', 'freq-desc': '🔥 많이 부른 순', 'freq-asc': '📉 적게 부른 순' };
+    const labels = { 'num': '🔢 번호순', 'freq-desc': '🔥 많이순', 'freq-asc': '📉 적게순' };
     const btn = document.getElementById('btn-sort-freq');
     if (btn) btn.textContent = labels[_sortMode];
     filterSongs();

--- a/style.css
+++ b/style.css
@@ -244,9 +244,9 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 .modal-header.history { background: var(--primary-container); }
 .modal-header h3 { margin: 0; font-family: 'Manrope', -apple-system, sans-serif; font-size: 17px; font-weight: 700; }
 .btn-close { background: none; border: none; color: rgba(255,255,255,0.65); font-size: 24px; cursor: pointer; }
-.modal-search { padding: 12px 16px; background: var(--surface-low); display: flex; align-items: center; gap: 10px; }
+.modal-search { padding: 12px 16px; background: var(--surface-low); display: flex; align-items: center; gap: 8px; overflow: hidden; }
 .modal-search input {
-    flex: 1; padding: 10px 0;
+    flex: 1; min-width: 0; padding: 10px 0;
     border: none; border-bottom: 2px solid var(--outline-variant);
     border-radius: 0; outline: none;
     font-family: 'Inter', -apple-system, sans-serif;
@@ -257,11 +257,13 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 .modal-search input:focus { border-bottom-color: var(--primary); }
 .btn-sort-freq {
     flex-shrink: 0; padding: 6px 10px;
+    max-width: 88px;
     background: var(--secondary-container); color: var(--on-secondary-container);
     border: none; border-radius: var(--r-full);
     font-family: 'Inter', -apple-system, sans-serif;
     font-size: 11px; font-weight: 700; cursor: pointer;
-    white-space: nowrap; transition: background 0.15s;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    transition: background 0.15s;
 }
 .btn-sort-freq:active { transform: scale(0.95); }
 .modal-body { position: relative; flex: 1; height: 100%; overflow-y: auto; padding: 0; margin: 0; list-style: none; scroll-behavior: smooth; -webkit-overflow-scrolling: touch; }


### PR DESCRIPTION
## Summary
- `.modal-search` flex 컨테이너에 `overflow: hidden` 추가, input에 `min-width: 0` 추가 → 플렉스 오버플로우 방지
- `.btn-sort-freq`에 `max-width: 88px` + `text-overflow: ellipsis` 적용 → 버튼이 절대 화면 밖으로 나가지 않음
- 정렬 레이블 단축: `🔥 많이 부른 순` → `🔥 많이순`, `📉 적게 부른 순` → `📉 적게순`

## Test plan
- [ ] 320px 폰에서 찬양 목록 모달 열어 정렬 버튼 위치 확인
- [ ] 🔢→🔥→📉 순으로 버튼 클릭 시 텍스트 정상 표시 확인
- [ ] 검색 입력창 너비가 정상적으로 줄어드는지 확인

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)