### PR TITLE
feat: 자주 쓰는 곡 즐겨찾기 기능 (Closes #55)

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,7 @@
             </div>
             <div class="modal-search">
                 <input type="text" id="searchInput" placeholder="검색어 또는 번호를 입력하세요..." onkeyup="filterSongs()">
+                <button id="btn-fav-filter" onclick="toggleFavFilter()" class="btn-sort-freq btn-fav-filter" title="즐겨찾기만 보기">⭐</button>
                 <button id="btn-sort-freq" onclick="cycleSortMode()" class="btn-sort-freq">🔢 번호순</button>
             </div>
                 <div style="position:relative; flex:1; display:flex; flex-direction:column; overflow:hidden; min-height:0;">

--- a/js/song-list.js
+++ b/js/song-list.js
@@ -4,6 +4,38 @@ let _prefetchObserver = null;
 let _songFreqData = {};  // { '001': 5, '276': 3, ... } 이력 집계 결과
 let _sortMode = 'num';  // 'num' | 'freq-desc' | 'freq-asc'
 
+// ─── 즐겨찾기 ─────────────────────────────────────────────────────────────────
+let _favorites = new Set(JSON.parse(localStorage.getItem('songFavorites') || '[]'));
+let _favFilterOn = false;
+
+function _saveFavorites() {
+    localStorage.setItem('songFavorites', JSON.stringify([..._favorites]));
+}
+
+function toggleFavorite(numPadded, btn) {
+    if (_favorites.has(numPadded)) {
+        _favorites.delete(numPadded);
+        btn.textContent = '☆';
+        btn.classList.remove('fav-on');
+    } else {
+        _favorites.add(numPadded);
+        btn.textContent = '★';
+        btn.classList.add('fav-on');
+    }
+    _saveFavorites();
+    if (_favFilterOn) filterSongs();
+}
+
+function toggleFavFilter() {
+    _favFilterOn = !_favFilterOn;
+    const btn = document.getElementById('btn-fav-filter');
+    if (btn) {
+        btn.classList.toggle('fav-filter-on', _favFilterOn);
+        btn.textContent = _favFilterOn ? '★' : '⭐';
+    }
+    filterSongs();
+}
+
 function cycleSortMode() {
     const modes = ['num', 'freq-desc', 'freq-asc'];
     _sortMode = modes[(modes.indexOf(_sortMode) + 1) % modes.length];
@@ -102,10 +134,13 @@ async function openSongModal() {
     modal.style.display = 'flex';
     searchInput.value = ''; // 검색창 비우기
     container.scrollTop = 0; // 스크롤 맨 위로 초기화 (중요!)
-    // 정렬 상태 초기화
+    // 정렬/필터 상태 초기화
     _sortMode = 'num';
     const sortBtn = document.getElementById('btn-sort-freq');
     if (sortBtn) sortBtn.textContent = '🔢 번호순';
+    _favFilterOn = false;
+    const favBtn = document.getElementById('btn-fav-filter');
+    if (favBtn) { favBtn.classList.remove('fav-filter-on'); favBtn.textContent = '⭐'; }
 
     if (songArray.length === 0) {
         // 첫 진입: 전체 초기화 (캐시 우선 + Firebase 동기화)
@@ -254,6 +289,15 @@ function filterSongs() {
         if (d.lyrics && d.lyrics.toLowerCase().includes(keyword)) return true;
         return false;
     }) : songArray;
+
+    // 즐겨찾기 필터
+    if (_favFilterOn) {
+        base = base.filter(song => {
+            const m = song.match(/^(\d+)/);
+            return m && _favorites.has(m[1].padStart(3, '0'));
+        });
+    }
+
     renderSongList(_applySortMode(base));
 }
 
@@ -286,6 +330,16 @@ function renderSongList(list) {
             badge.className = `freq-badge${freq >= 5 ? ' freq-badge-high' : freq >= 3 ? ' freq-badge-med' : ' freq-badge-low'}`;
             badge.textContent = `♪${freq}`;
             li.appendChild(badge);
+        }
+
+        // 즐겨찾기 버튼
+        if (match) {
+            const favBtn = document.createElement('button');
+            favBtn.className = 'btn-fav' + (_favorites.has(numPadded) ? ' fav-on' : '');
+            favBtn.textContent = _favorites.has(numPadded) ? '★' : '☆';
+            favBtn.title = '즐겨찾기';
+            favBtn.onclick = (e) => { e.stopPropagation(); toggleFavorite(numPadded, favBtn); };
+            li.appendChild(favBtn);
         }
 
         const lyricEntry = lyricsData[numPadded];

--- a/style.css
+++ b/style.css
@@ -432,6 +432,18 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
 .btn-install { background: var(--primary); color: #ffffff; }
 .btn-notify  { background: var(--secondary-container); color: var(--on-secondary-container); }
 
+/* ─── Favorites ─── */
+.btn-fav {
+    flex-shrink: 0; padding: 4px 7px;
+    background: transparent; color: var(--outline-variant);
+    border: none; border-radius: var(--r-full);
+    font-size: 14px; cursor: pointer; line-height: 1;
+    transition: color 0.15s, transform 0.1s;
+}
+.btn-fav.fav-on { color: #f59e0b; }
+.btn-fav:active { transform: scale(1.25); }
+.btn-fav-filter.fav-filter-on { background: #f59e0b; color: #fff; }
+
 /* ─── Lyrics ─── */
 .btn-lyrics {
     flex-shrink: 0; padding: 5px 12px;


### PR DESCRIPTION
## Summary
- 각 곡 옆 `☆/★` 버튼으로 즐겨찾기 토글 → `localStorage('songFavorites')` 저장
- 검색창 옆 `⭐` 버튼으로 즐겨찾기 곡만 필터링 (활성 시 황금색 `★` 로 변경)
- 즐겨찾기 필터 ON 상태에서 ★ 토글 시 목록 즉시 갱신
- 모달을 열 때마다 즐겨찾기 필터는 초기화 (전체 목록 표시)

## 구현 세부
| 파일 | 변경 내용 |
|------|----------|
| `js/song-list.js` | `_favorites` Set, `toggleFavorite()`, `toggleFavFilter()`, `filterSongs()` 즐겨찾기 필터, `renderSongList()` ★ 버튼 |
| `index.html` | 모달 검색창에 `#btn-fav-filter` 버튼 추가 |
| `style.css` | `.btn-fav`, `.btn-fav.fav-on`, `.btn-fav-filter.fav-filter-on` 스타일 |

## Test plan
- [ ] 곡 옆 ☆ 클릭 → ★ 로 변경, 재오픈 시에도 ★ 유지 확인
- [ ] ⭐ 버튼 클릭 → 즐겨찾기 곡만 표시, 황금색 활성 상태 확인
- [ ] 즐겨찾기가 없을 때 ⭐ 필터 클릭 시 빈 목록 표시 확인
- [ ] 모달 닫고 재오픈 시 필터 상태 초기화 확인

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)