### PR TITLE
feat: 악보 핀치 줌 구현 (#53)

### DIFF
--- a/js/sheet-viewer.js
+++ b/js/sheet-viewer.js
@@ -115,7 +115,7 @@ function openFullscreen(index) {
     currentSheetIndex = index;
     const sheet = sheetList[index];
     if (!sheet) return;
-    
+
     const imgEl = document.getElementById('fullscreen-img');
     if (sheet.src) {
         imgEl.src = sheet.src;
@@ -124,7 +124,8 @@ function openFullscreen(index) {
         imgEl.src = "";
         imgEl.style.display = 'none';
     }
-    
+
+    if (window._resetFullscreenZoom) window._resetFullscreenZoom();
     updateFullscreenTitle(index);
     document.getElementById('fullscreenViewer').style.display = 'flex';
     updateNavBtns();
@@ -153,7 +154,7 @@ function showLsSheet(index) {
     const sheet = sheetList[index];
     if (!sheet) return;
     currentSheetIndex = index;
-    
+
     const imgEl = document.getElementById('ls-sheet-img');
     if (sheet.src) {
         imgEl.src = sheet.src;
@@ -162,7 +163,8 @@ function showLsSheet(index) {
         imgEl.src = "";
         imgEl.style.display = 'none';
     }
-    
+
+    if (window._resetLsZoom) window._resetLsZoom();
     document.getElementById('ls-sheet-title').textContent =
         `${sheet.label}  (${visibleSheetRank(index)}/${visibleSheetCount()})`;
     updateLsNavBtns();
@@ -187,31 +189,134 @@ function updateLsNavBtns() {
 
 function closeLandscapeView() { document.getElementById('app-layout').classList.remove('ls-active'); }
 
-// 터치 스와이프 (전체화면 뷰어: 좌우=페이지이동, 하단=닫기)
+// 터치: 전체화면 뷰어 (핀치줌 + 패닝 + 스와이프 + 더블탭 리셋)
 (() => {
-    let touchStartX = 0, touchStartY = 0;
     const viewer = document.getElementById('fullscreenViewer');
+    const imgEl  = document.getElementById('fullscreen-img');
+
+    let scale = 1, tx = 0, ty = 0;
+    let touchStartX = 0, touchStartY = 0;
+    let panStartX = 0, panStartY = 0, panStartTX = 0, panStartTY = 0;
+    let isPinching = false, pinchStartDist = 0, pinchStartScale = 1;
+    let lastTapTime = 0;
+
+    function applyTransform() {
+        imgEl.style.transform = `scale(${scale}) translate(${tx}px, ${ty}px)`;
+    }
+    function resetZoom() { scale = 1; tx = 0; ty = 0; applyTransform(); }
+    window._resetFullscreenZoom = resetZoom;
+
+    function dist2(t0, t1) {
+        const dx = t0.clientX - t1.clientX, dy = t0.clientY - t1.clientY;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
     viewer.addEventListener('touchstart', e => {
-        touchStartX = e.touches[0].clientX; touchStartY = e.touches[0].clientY;
+        if (e.touches.length === 2) {
+            isPinching = true;
+            pinchStartDist  = dist2(e.touches[0], e.touches[1]);
+            pinchStartScale = scale;
+            e.preventDefault();
+        } else if (e.touches.length === 1) {
+            isPinching = false;
+            const now = Date.now();
+            if (now - lastTapTime < 280) { resetZoom(); lastTapTime = 0; e.preventDefault(); return; }
+            lastTapTime = now;
+            touchStartX = panStartX = e.touches[0].clientX;
+            touchStartY = panStartY = e.touches[0].clientY;
+            panStartTX = tx; panStartTY = ty;
+        }
     }, { passive: false });
-    viewer.addEventListener('touchmove', e => { e.preventDefault(); }, { passive: false });
+
+    viewer.addEventListener('touchmove', e => {
+        if (e.touches.length === 2 && isPinching) {
+            const newScale = Math.min(4, Math.max(1, pinchStartScale * (dist2(e.touches[0], e.touches[1]) / pinchStartDist)));
+            scale = newScale;
+            applyTransform();
+            e.preventDefault();
+        } else if (e.touches.length === 1) {
+            if (scale > 1) {
+                tx = panStartTX + (e.touches[0].clientX - panStartX) / scale;
+                ty = panStartTY + (e.touches[0].clientY - panStartY) / scale;
+                applyTransform();
+                e.preventDefault();
+            } else {
+                e.preventDefault();
+            }
+        }
+    }, { passive: false });
+
     viewer.addEventListener('touchend', e => {
-        const dx = e.changedTouches[0].clientX - touchStartX;
-        const dy = e.changedTouches[0].clientY - touchStartY;
-        if (dy > 80 && Math.abs(dy) > Math.abs(dx)) { closeFullscreen(); }
-        else if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) { navigateSheet(dx < 0 ? 1 : -1); }
+        if (isPinching) { isPinching = false; return; }
+        if (scale <= 1 && e.changedTouches.length === 1) {
+            const dx = e.changedTouches[0].clientX - touchStartX;
+            const dy = e.changedTouches[0].clientY - touchStartY;
+            if (dy > 80 && Math.abs(dy) > Math.abs(dx)) { closeFullscreen(); }
+            else if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) { navigateSheet(dx < 0 ? 1 : -1); }
+        }
     }, { passive: true });
 })();
 
-// landscape 악보 뷰어 좌우 스와이프
+// 터치: Landscape 뷰어 (핀치줌 + 패닝 + 좌우 스와이프 + 더블탭 리셋)
 (() => {
-    let tsX = 0, tsY = 0;
     const lsArea = document.getElementById('ls-sheet-area');
-    lsArea.addEventListener('touchstart', e => { tsX = e.touches[0].clientX; tsY = e.touches[0].clientY; }, { passive: true });
+    const imgEl  = document.getElementById('ls-sheet-img');
+
+    let scale = 1, tx = 0, ty = 0;
+    let tsX = 0, tsY = 0;
+    let panStartX = 0, panStartY = 0, panStartTX = 0, panStartTY = 0;
+    let isPinching = false, pinchStartDist = 0, pinchStartScale = 1;
+    let lastTapTime = 0;
+
+    function applyTransform() {
+        imgEl.style.transform = `scale(${scale}) translate(${tx}px, ${ty}px)`;
+    }
+    function resetZoom() { scale = 1; tx = 0; ty = 0; applyTransform(); }
+    window._resetLsZoom = resetZoom;
+
+    function dist2(t0, t1) {
+        const dx = t0.clientX - t1.clientX, dy = t0.clientY - t1.clientY;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    lsArea.addEventListener('touchstart', e => {
+        if (e.touches.length === 2) {
+            isPinching = true;
+            pinchStartDist  = dist2(e.touches[0], e.touches[1]);
+            pinchStartScale = scale;
+            e.preventDefault();
+        } else if (e.touches.length === 1) {
+            isPinching = false;
+            const now = Date.now();
+            if (now - lastTapTime < 280) { resetZoom(); lastTapTime = 0; e.preventDefault(); return; }
+            lastTapTime = now;
+            tsX = panStartX = e.touches[0].clientX;
+            tsY = panStartY = e.touches[0].clientY;
+            panStartTX = tx; panStartTY = ty;
+        }
+    }, { passive: false });
+
+    lsArea.addEventListener('touchmove', e => {
+        if (e.touches.length === 2 && isPinching) {
+            const newScale = Math.min(4, Math.max(1, pinchStartScale * (dist2(e.touches[0], e.touches[1]) / pinchStartDist)));
+            scale = newScale;
+            applyTransform();
+            e.preventDefault();
+        } else if (e.touches.length === 1 && scale > 1) {
+            tx = panStartTX + (e.touches[0].clientX - panStartX) / scale;
+            ty = panStartTY + (e.touches[0].clientY - panStartY) / scale;
+            applyTransform();
+            e.preventDefault();
+        }
+    }, { passive: false });
+
     lsArea.addEventListener('touchend', e => {
-        const dx = e.changedTouches[0].clientX - tsX;
-        const dy = e.changedTouches[0].clientY - tsY;
-        if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) { navigateLandscapeSheet(dx < 0 ? 1 : -1); }
+        if (isPinching) { isPinching = false; return; }
+        if (scale <= 1 && e.changedTouches.length === 1) {
+            const dx = e.changedTouches[0].clientX - tsX;
+            const dy = e.changedTouches[0].clientY - tsY;
+            if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) { navigateLandscapeSheet(dx < 0 ? 1 : -1); }
+        }
     }, { passive: true });
 })();
 

--- a/style.css
+++ b/style.css
@@ -206,7 +206,7 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
     flex: 1; overflow: hidden; display: flex;
     justify-content: center; align-items: center;
 }
-.fullscreen-body img { width: 100%; height: 100%; object-fit: contain; display: block; }
+.fullscreen-body img { width: 100%; height: 100%; object-fit: contain; display: block; transform-origin: center center; will-change: transform; }
 .fullscreen-footer {
     display: flex; justify-content: space-between; align-items: center;
     background: rgba(24, 29, 58, 0.88);
@@ -529,7 +529,7 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
     flex: 1; overflow: hidden; display: flex;
     align-items: center; justify-content: center; min-height: 0;
 }
-.ls-sheet-body img { width: 100%; height: 100%; object-fit: contain; display: block; }
+.ls-sheet-body img { width: 100%; height: 100%; object-fit: contain; display: block; transform-origin: center center; will-change: transform; }
 .ls-sheet-footer {
     display: flex; justify-content: space-between; align-items: center;
     background: rgba(24, 29, 58, 0.88);


### PR DESCRIPTION
## Summary
- 전체화면 뷰어 + 가로 분할 뷰어 양쪽에 핀치 줌 적용
- 2손가락 핀치: 1x~4x 확대/축소
- 확대 중 1손가락 드래그로 패닝
- 확대 상태에서 스와이프/하단닫기 비활성화 → 스케일 1 복귀 시 자동 재활성
- 더블탭으로 즉시 줌 리셋, 악보 페이지 전환 시 자동 리셋
- will-change: transform 으로 GPU 가속 렌더링 최적화

## Test plan
- [ ] 전체화면 뷰어에서 두 손가락 핀치 확대/축소
- [ ] 확대 상태에서 한 손가락 드래그로 패닝
- [ ] 확대 상태에서 스와이프 → 페이지 이동 안 됨 확인
- [ ] 더블탭 → 줌 리셋 확인
- [ ] 다음 악보로 이동 시 줌 자동 리셋 확인
- [ ] 태블릿 가로 모드 분할 뷰어에서 동일 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)