### PR TITLE
fix: 가로 모드 버그 수정 + 세로 모드 카드 그리드 (#67 #72 #73)

### DIFF
--- a/js/sheet-viewer.js
+++ b/js/sheet-viewer.js
@@ -21,6 +21,7 @@ function tryLoadImage(imgElement, songNum, extIndex, onDone) {
 }
 
 async function startSearch() {
+    _lsUserDismissed = false; // 악보 만들기 실행 시 플래그 초기화
     const rawText = document.getElementById('song-input').value;
 
     // 공통 정규화: 곡번호 3자리 + 제목 자동 치환
@@ -296,7 +297,12 @@ function updateLsNavBtns() {
     if (next) next.classList.toggle('hidden', !hasNext);
 }
 
-function closeLandscapeView() { document.getElementById('app-layout').classList.remove('ls-active'); }
+// 사용자가 직접 가로 뷰를 닫은 경우 resize로 재활성화 방지
+let _lsUserDismissed = false;
+function closeLandscapeView() {
+    document.getElementById('app-layout').classList.remove('ls-active');
+    _lsUserDismissed = true;
+}
 
 // 터치: 전체화면 뷰어 (핀치줌 + 패닝 + 스와이프 + 더블탭 리셋)
 (() => {
@@ -439,16 +445,13 @@ window.addEventListener('resize', () => {
     if (isLS && !isTabletLandscape()) {
         // 1. 가로 모드(분할 뷰)였다가 세로 모드(모바일 뷰)로 변한 경우
         const lastIdx = currentSheetIndex;
-        // 즉시 클래스 제거하여 media query가 result-container를 보이게 함
         layout.classList.remove('ls-active');
-        
-        // DOM 구조가 다르므로 세로용 리스트 강제 재생성
-        startSearch(); 
-        
+        _lsUserDismissed = false; // 실제 회전이므로 플래그 초기화
+        startSearch();
         if (lastIdx >= 0 && sheetList[lastIdx]) {
             setTimeout(() => openFullscreen(lastIdx), 100);
         }
-    } 
+    }
     else if (isFS && isTabletLandscape()) {
         // 2. 세로 모드(전체화면)였다가 가로 모드(태블릿 분할 뷰)로 변한 경우
         const lastIdx = currentSheetIndex;
@@ -459,8 +462,9 @@ window.addEventListener('resize', () => {
             setTimeout(() => showLsSheet(lastIdx), 150);
         }
     }
-    else if (!isLS && !isFS && sheetList.length > 0 && isTabletLandscape()) {
+    else if (!isLS && !isFS && sheetList.length > 0 && isTabletLandscape() && !_lsUserDismissed) {
         // 3. 악보가 있는 세로 모드에서 가로 모드로 전환된 경우 → 분할 뷰 자동 전환
+        // (_lsUserDismissed=true면 사용자가 직접 닫은 것이므로 재활성화 안 함)
         layout.classList.add('ls-active');
         startSearch();
         setTimeout(() => showLsSheet(currentSheetIndex >= 0 ? currentSheetIndex : 0), 150);

--- a/style.css
+++ b/style.css
@@ -174,16 +174,24 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 
 /* ─── Result Area ─── */
 .result-area { margin-top: 20px; }
+#result-container {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+}
+@media (max-width: 479px) {
+    #result-container { grid-template-columns: repeat(2, 1fr); gap: 10px; }
+}
 .sheet-music-card {
     background: #ffffff; border-radius: var(--r-xl);
-    padding: 16px; margin-bottom: 16px;
+    padding: 12px;
     box-shadow: 0 4px 20px var(--shadow);
     outline: 1px solid rgba(199, 197, 206, 0.15);
     cursor: pointer; transition: box-shadow 0.2s;
 }
 .sheet-music-card:active { box-shadow: 0 8px 28px rgba(24,29,58,0.15); }
 .sheet-music-card img { width: 100%; height: auto; border-radius: 8px; min-height: 100px; background: var(--surface-low); }
-.sheet-title { margin-bottom: 12px; font-family: 'Manrope', -apple-system, sans-serif; font-weight: 700; color: var(--primary); font-size: 15px; letter-spacing: -0.2px; display: flex; align-items: center; gap: 8px; }
+.sheet-title { margin-bottom: 8px; font-family: 'Manrope', -apple-system, sans-serif; font-weight: 700; color: var(--primary); font-size: 13px; letter-spacing: -0.2px; display: flex; align-items: center; gap: 6px; }
 .drag-handle { font-size: 20px; color: rgba(99,102,241,0.45); cursor: grab; user-select: none; -webkit-user-select: none; flex-shrink: 0; padding: 2px 4px; touch-action: none; transition: color 0.15s; }
 .drag-handle:active { cursor: grabbing; color: rgba(99,102,241,0.85); }
 .card-dragging { opacity: 0.25; pointer-events: none; }
@@ -689,6 +697,14 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
     /* 모달 */
     .song-item { font-size: 15px; padding: 13px 16px; }
     .btn-lyrics { font-size: 13px; padding: 6px 14px; }
+}
+
+/* ─── 모바일 가로 모드 전체화면 뷰어 버튼 축소 (#67) ─── */
+@media (max-width: 767px) and (orientation: landscape) {
+    .fullscreen-nav { font-size: 22px; padding: 8px 0; }
+    .fullscreen-header { padding: 8px 14px; }
+    .fullscreen-header .btn-close { font-size: 22px; }
+    .fullscreen-footer { padding: 6px 10px; }
 }
 
 /* ─── 세로 모드 소형 화면 버튼 폰트/패딩 조정 (#42) ─── */


### PR DESCRIPTION
## Summary
- **[#72] bug**: 가로 모드 돌아가기 후 textarea 터치 시 다시 전체화면 전환 버그 수정
  - 원인: 소프트 키보드 open/close 시 resize 이벤트 → 케이스3 조건 충족 → ls-active 재활성화
  - `_lsUserDismissed` 플래그로 사용자가 직접 닫은 경우 resize로 재활성화 차단
  - 실제 화면 회전(세로→가로)이나 악보 만들기 버튼 시 플래그 초기화
- **[#67] bug**: 모바일 가로 모드 전체화면 뷰어 내비 버튼 너무 큰 문제
  - `@media (max-width: 767px) and (landscape)` 추가: 버튼 22px, 헤더/푸터 패딩 축소
- **[#73] enhancement**: 세로 모드 악보 카드 3열 그리드 레이아웃
  - 전체 악보 순서를 한 화면에서 한눈에 파악 가능
  - 480px 이하 소형 폰은 2열 그리드

## Test plan
- [ ] 가로 모드에서 악보 만들기 → 돌아가기 → textarea 터치 → 전체화면 전환 안 됨 확인
- [ ] 가로 모드에서 돌아가기 후, 화면 돌려서 세로→가로 → 자동 분할뷰 복귀 정상 작동 확인
- [ ] 모바일 가로 전체화면 뷰어에서 내비 버튼 크기 적절함 확인
- [ ] 세로 모드 악보 카드 3열 그리드로 표시 확인
- [ ] 드래그 핸들 여전히 표시/동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)