### PR TITLE
feat: 가로→세로 회전 뷰어 유지 + 반응형 UI 개선 (#68 #71)

### DIFF
--- a/js/sheet-viewer.js
+++ b/js/sheet-viewer.js
@@ -448,8 +448,13 @@ window.addEventListener('resize', () => {
         layout.classList.remove('ls-active');
         _lsUserDismissed = false; // 실제 회전이므로 플래그 초기화
         startSearch();
-        if (lastIdx >= 0 && sheetList[lastIdx]) {
-            setTimeout(() => openFullscreen(lastIdx), 100);
+        if (lastIdx >= 0) {
+            // 이미지 로드 완료 대기 후 전체화면 오픈 (#68)
+            const _waitAndOpen = () => {
+                if (sheetList[lastIdx]) openFullscreen(lastIdx);
+                else setTimeout(_waitAndOpen, 80);
+            };
+            setTimeout(_waitAndOpen, 80);
         }
     }
     else if (isFS && isTabletLandscape()) {

--- a/style.css
+++ b/style.css
@@ -49,9 +49,9 @@ header {
     background: rgba(24, 29, 58, 0.96);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    padding: 10px 16px; text-align: center;
+    padding: clamp(8px, 2.5vw, 11px) 16px; text-align: center;
     font-family: 'Manrope', -apple-system, sans-serif;
-    font-weight: 800; font-size: 16px; color: #ffffff;
+    font-weight: 800; font-size: clamp(14px, 4vw, 17px); color: #ffffff;
     letter-spacing: -0.3px;
     position: sticky; top: 0; z-index: 10;
     display: flex; align-items: center; justify-content: center;
@@ -67,12 +67,12 @@ header {
 }
 .header-settings-btn:active { background: rgba(255,255,255,0.25); }
 
-main { flex: 1; overflow-y: auto; padding: 12px; padding-bottom: 20px; }
+main { flex: 1; overflow-y: auto; padding: clamp(8px, 3vw, 14px); padding-bottom: 20px; }
 
 /* ─── Input Card ─── */
 .input-card {
     background: var(--surface-low);
-    border-radius: var(--r-xl); padding: 14px 16px;
+    border-radius: var(--r-xl); padding: clamp(12px, 3.5vw, 16px) clamp(12px, 4vw, 18px);
     outline: 1px solid rgba(199, 197, 206, 0.2);
     box-shadow: 0 4px 20px var(--shadow);
 }
@@ -80,7 +80,7 @@ main { flex: 1; overflow-y: auto; padding: 12px; padding-bottom: 20px; }
 /* ─── Field Label ─── */
 .field-label {
     display: block; font-family: 'Inter', sans-serif;
-    font-size: 11px; font-weight: 700;
+    font-size: clamp(10px, 2.8vw, 12px); font-weight: 700;
     color: var(--on-surface-variant);
     letter-spacing: 0.06em; text-transform: uppercase;
     margin-bottom: 4px;
@@ -92,7 +92,7 @@ main { flex: 1; overflow-y: auto; padding: 12px; padding-bottom: 20px; }
     border: none; border-bottom: 2px solid var(--outline-variant);
     border-radius: 0; outline: none;
     font-family: 'Manrope', -apple-system, sans-serif;
-    font-size: 15px; font-weight: 700;
+    font-size: clamp(13px, 3.8vw, 16px); font-weight: 700;
     color: var(--primary); background: transparent;
     box-sizing: border-box; margin-bottom: 12px;
     transition: border-color 0.2s;
@@ -107,7 +107,7 @@ textarea {
     border-radius: 0; outline: none;
     padding: 7px 0;
     font-family: 'Inter', -apple-system, sans-serif;
-    font-size: 14px; color: var(--on-surface);
+    font-size: clamp(13px, 3.6vw, 15px); color: var(--on-surface);
     background: transparent; box-sizing: border-box;
     resize: none; line-height: 1.6;
     transition: border-color 0.2s;
@@ -119,10 +119,10 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 .top-btn-group { display: flex; flex-direction: column; gap: 7px; }
 .top-btn-row   { display: flex; gap: 7px; }
 .top-btn {
-    flex: 1; padding: 12px 8px;
+    flex: 1; padding: clamp(10px, 3vw, 13px) 8px;
     border: none; border-radius: var(--r-lg);
     font-family: 'Manrope', -apple-system, sans-serif;
-    font-size: 14px; font-weight: 800;
+    font-size: clamp(12px, 3.5vw, 15px); font-weight: 800;
     cursor: pointer; text-align: center;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     transition: opacity 0.15s, transform 0.1s;
@@ -137,11 +137,11 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 .btn-row   { display: flex; gap: 8px; }
 
 .btn-search {
-    width: 100%; padding: 13px 8px;
+    width: 100%; padding: clamp(11px, 3.2vw, 14px) 8px;
     background: linear-gradient(135deg, var(--primary) 0%, var(--primary-container) 100%);
     color: #ffffff; border: none; border-radius: var(--r-lg);
     font-family: 'Manrope', -apple-system, sans-serif;
-    font-size: 15px; font-weight: 800; letter-spacing: -0.2px;
+    font-size: clamp(13px, 4vw, 16px); font-weight: 800; letter-spacing: -0.2px;
     cursor: pointer;
     box-shadow: 0 6px 20px rgba(24, 29, 58, 0.3);
     transition: box-shadow 0.2s, transform 0.1s;
@@ -149,24 +149,24 @@ textarea::placeholder { color: var(--outline-variant); font-size: 13px; }
 .btn-search:active { transform: scale(0.98); box-shadow: 0 2px 8px rgba(24,29,58,0.2); }
 
 .btn-save {
-    flex: 1; padding: 13px 8px;
+    flex: 1; padding: clamp(11px, 3.2vw, 14px) 8px;
     background: linear-gradient(135deg, #059669 0%, #34D399 100%);
     color: #ffffff;
     border: none; border-radius: var(--r-lg);
     font-family: 'Manrope', -apple-system, sans-serif;
-    font-size: 14px; font-weight: 800; cursor: pointer;
+    font-size: clamp(12px, 3.5vw, 15px); font-weight: 800; cursor: pointer;
     box-shadow: 0 4px 14px rgba(5, 150, 105, 0.3);
     transition: box-shadow 0.15s, transform 0.1s;
 }
 .btn-save:active { box-shadow: 0 2px 6px rgba(5, 150, 105, 0.2); transform: scale(0.97); }
 
 .btn-share {
-    flex: 1; padding: 13px 8px;
+    flex: 1; padding: clamp(11px, 3.2vw, 14px) 8px;
     background: linear-gradient(135deg, #F59E0B 0%, #FCD34D 100%);
     color: #78350F;
     border: none; border-radius: var(--r-lg);
     font-family: 'Manrope', -apple-system, sans-serif;
-    font-size: 14px; font-weight: 800; cursor: pointer;
+    font-size: clamp(12px, 3.5vw, 15px); font-weight: 800; cursor: pointer;
     box-shadow: 0 4px 14px rgba(245, 158, 11, 0.3);
     transition: box-shadow 0.15s, transform 0.1s;
 }
@@ -507,7 +507,7 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
 
 .controls-card {
     background: var(--surface-low);
-    border-radius: var(--r-xl); padding: 14px 16px;
+    border-radius: var(--r-xl); padding: clamp(12px, 3.5vw, 16px) clamp(12px, 4vw, 18px);
     outline: 1px solid rgba(199, 197, 206, 0.2);
     box-shadow: 0 4px 20px var(--shadow);
 }
@@ -707,11 +707,11 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
     .fullscreen-footer { padding: 6px 10px; }
 }
 
-/* ─── 세로 모드 소형 화면 버튼 폰트/패딩 조정 (#42) ─── */
-@media (max-width: 390px) and (orientation: portrait) {
-    .top-btn { padding: 10px 6px; font-size: 13px; }
-    .btn-search { font-size: 14px; }
-    .btn-save, .btn-share { font-size: 13px; }
+/* 소형 화면 (#42) — clamp()로 대부분 커버, 극소형(320px 이하)만 명시 */
+@media (max-width: 320px) {
+    .top-btn { font-size: 11px; padding: 9px 6px; }
+    .btn-search { font-size: 12px; }
+    .btn-save, .btn-share { font-size: 11px; }
 }
 
 /* ─── Settings Modal ─── */


### PR DESCRIPTION
## Summary

### #68 — 가로→세로 회전 시 전체화면 뷰어 유지
- 기존: 가로 분할뷰에서 세로로 회전하면 카드 리스트만 표시되고 악보 뷰어가 닫힘
- 개선: 회전 후 현재 보던 악보를 전체화면 뷰어로 자동 오픈
- 방법: 이미지 로드 완료까지 80ms 폴링 후 `openFullscreen()` 호출 (기존 고정 100ms 타임아웃 제거)

### #71 — 반응형 UI 비율 자동 스케일링
- 기존: 고정 px 값으로 360px 소형폰 / 8인치 태블릿에서 비율 불일치
- 개선: CSS `clamp(min, vw기반선호, max)` 적용으로 화면 너비에 따라 자연스럽게 스케일링

| 요소 | 변경 전 | 변경 후 |
|------|---------|---------|
| 헤더 폰트 | 16px 고정 | clamp(14px, 4vw, 17px) |
| top-btn 폰트 | 14px 고정 | clamp(12px, 3.5vw, 15px) |
| btn-search 폰트 | 15px 고정 | clamp(13px, 4vw, 16px) |
| 입력창 폰트 | 14-15px 고정 | clamp(13px, 3.6-3.8vw, 15-16px) |
| 카드 패딩 | 14px 16px 고정 | clamp(12px, 3.5vw, 16px) |

## Test plan
- [ ] 가로 분할뷰에서 세로로 회전 → 현재 악보 전체화면 자동 오픈 확인
- [ ] 360px 소형폰에서 버튼/헤더 크기 적절함 확인
- [ ] 430px 일반폰에서 크기 동일하게 유지 확인
- [ ] 8인치 태블릿 portrait에서 버튼 크기 충분히 큰지 확인 (기존 768px+ 미디어쿼리 override 적용)
- [ ] 320px 이하 극소형 폰 별도 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)