### PR TITLE
feat: 세로모드 중간 영역(textarea) 가변 높이 + 하단 버튼 화면 맨 아래 고정

### DIFF
--- a/style.css
+++ b/style.css
@@ -133,6 +133,7 @@ main { flex: 1; overflow-y: auto; padding: clamp(8px, 3vw, 14px); padding-bottom
     border-radius: var(--r-xl); padding: clamp(12px, 3.5vw, 16px) clamp(12px, 4vw, 18px);
     outline: 1px solid rgba(199, 197, 206, 0.2);
     box-shadow: 0 4px 20px var(--shadow);
+    flex: 1; display: flex; flex-direction: column;
 }
 
 /* ─── Field Label ─── */
@@ -160,7 +161,7 @@ main { flex: 1; overflow-y: auto; padding: clamp(8px, 3vw, 14px); padding-bottom
 
 /* ─── Textarea ─── */
 textarea {
-    width: 100%; height: 100px;
+    width: 100%; flex: 1; height: auto; min-height: 80px;
     border: none; border-bottom: 2px solid var(--outline-variant);
     border-radius: 0; outline: none;
     padding: 7px 0;
@@ -656,11 +657,11 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
 }
 
 /* ─── App Layout (세로/가로 공통) ─── */
-.app-layout { display: flex; flex-direction: column; gap: 10px; }
+.app-layout { display: flex; flex-direction: column; gap: 10px; min-height: 100%; }
 /* 세로 모드: 상단버튼(right) 위, 입력(left) 중간, 하단버튼(bottom) 아래 */
-.panel-right  { order: 1; }
-.panel-left   { order: 2; }
-.panel-bottom { order: 3; }
+.panel-right  { order: 1; flex-shrink: 0; }
+.panel-left   { order: 2; flex: 1; display: flex; flex-direction: column; }
+.panel-bottom { order: 3; flex-shrink: 0; }
 
 .controls-card {
     background: var(--surface-low);
@@ -734,6 +735,7 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
     .app-layout {
         display: grid;
         flex: 1; /* main(flex col)을 꽉 채워 높이를 고정 */
+        min-height: auto; /* 세로모드 min-height: 100% 리셋 */
         grid-template-columns: 4fr 3fr;
         grid-template-rows: auto 1fr; /* row2(panel-bottom)가 남은 높이 채움 */
         gap: 10px;
@@ -770,9 +772,9 @@ footer svg { width: 18px; height: 18px; fill: currentColor; }
     /* panel-left 스크롤: min-height:0 필수 (grid child) */
     .panel-left { min-height: 0; }
 
-    /* 입력 카드 가로 모드 */
-    .panel-left .input-card { margin-bottom: 0; flex-shrink: 0; }
-    .panel-left .input-card textarea { height: clamp(80px, 20vh, 180px); min-height: 80px; }
+    /* 입력 카드 가로 모드 — 세로모드 flex: 1 리셋 */
+    .panel-left .input-card { margin-bottom: 0; flex: none; }
+    .panel-left .input-card textarea { flex: none; height: clamp(80px, 20vh, 180px); min-height: 80px; }
 
     /* ── ls-active: 악보 만들기 후 분할 뷰어 ── */
     .app-layout.ls-active {


### PR DESCRIPTION
- app-layout min-height: 100% → main의 뷰포트 높이를 채워 panel-bottom이 항상 화면 하단에 위치
- panel-left flex: 1 → 상단/하단 버튼 사이 중간 영역이 가변적으로 늘어남
- panel-right / panel-bottom flex-shrink: 0 → 버튼 영역이 줄어들지 않도록 고정
- input-card flex: 1 + display: flex column → panel-left 높이를 꽉 채움
- textarea flex: 1 + height: auto + min-height: 80px → 남는 공간을 모두 채워 가변 높이 적용
- 가로 모드 리셋: min-height: auto, flex: none 추가 → 기존 가로 레이아웃 영향 없음
- 악보 카드는 app-layout 아래에 스크롤로 조회 (기존 동작 유지)

https://claude.ai/code/session_01CDzbgrhL6ELDbpSKe7iLpx