### PR TITLE
fix: 찬양목록 미리보기 스와이프 이동 불가 수정

### DIFF
--- a/js/sheet-viewer.js
+++ b/js/sheet-viewer.js
@@ -709,6 +709,24 @@ function closeLandscapeView() {
         if (scale <= 1 && e.changedTouches.length === 1) {
             if (isSwiping && Math.abs(swipeDeltaX) > 50) {
                 const dir = swipeDeltaX < 0 ? 1 : -1;
+                if (_scorePreviewFromModal && _scorePreviewList.length > 0) {
+                    // 찬양목록 미리보기 모드: _scorePreviewList 기반 범위 확인
+                    const newPreviewIdx = _scorePreviewIdx + dir;
+                    if (newPreviewIdx < 0 || newPreviewIdx >= _scorePreviewList.length) {
+                        // 첫/마지막 — 스프링백
+                        imgEl.style.transition = 'transform 0.2s ease';
+                        imgEl.style.transform = 'scale(1) translate(0, 0)';
+                    } else {
+                        const vw = viewer.clientWidth;
+                        imgEl.style.transition = 'transform 0.18s ease';
+                        imgEl.style.transform = `translate(${dir > 0 ? -vw : vw}px, 0) scale(1)`;
+                        setTimeout(() => {
+                            imgEl.style.transition = 'none';
+                            imgEl.style.transform = 'scale(1) translate(0, 0)';
+                            navigateScorePreview(dir);
+                        }, 180);
+                    }
+                } else {
                 // 유효한 다음 시트 확인 (#143)
                 let chkIdx = currentSheetIndex + dir;
                 while (chkIdx >= 0 && chkIdx < sheetList.length && !sheetList[chkIdx]) chkIdx += dir;
@@ -717,16 +735,6 @@ function closeLandscapeView() {
                     // 첫/마지막 페이지 무효 방향 — 스프링백
                     imgEl.style.transition = 'transform 0.2s ease';
                     imgEl.style.transform = 'scale(1) translate(0, 0)';
-                } else if (_scorePreviewFromModal && _scorePreviewList.length > 0) {
-                    // 찬양목록 미리보기 모드: nextImg 없이 imgEl만 슬라이드 후 navigateScorePreview 직접 호출
-                    const vw = viewer.clientWidth;
-                    imgEl.style.transition = 'transform 0.18s ease';
-                    imgEl.style.transform = `translate(${dir > 0 ? -vw : vw}px, 0) scale(1)`;
-                    setTimeout(() => {
-                        imgEl.style.transition = 'none';
-                        imgEl.style.transform = 'scale(1) translate(0, 0)';
-                        navigateScorePreview(dir);
-                    }, 180);
                 } else {
                 const vw = viewer.clientWidth;
                 const exitX = dir > 0 ? -vw : vw;
@@ -743,6 +751,7 @@ function closeLandscapeView() {
                     navigateSheet(dir);
                     _realtimeSwipeDone = false;
                 }, 180);
+                }
                 }
             } else if (isSwiping) {
                 imgEl.style.transition = 'transform 0.2s ease';


### PR DESCRIPTION
## 원인

PR#166 수정 후 찬양목록 미리보기에서 스와이프로 좌우 이동이 아예 안 되는 버그.

`hasValidNext` 가 `sheetList[]` (콘티 데이터) 기반으로 계산되어, 찬양목록 미리보기 모드(`_scorePreviewFromModal=true`)에서는 항상 `false`가 되어버려 스프링백 분기에서 막힘.

```
// 기존 실행 순서 (문제)
hasValidNext = sheetList[] 기반 계산  ← 찬양목록 모드에서 콘티 인덱스 참조
if (!hasValidNext) → 스프링백          ← 여기서 항상 걸려버림
else if (_scorePreviewFromModal) → navigateScorePreview()  ← 도달 불가
```

## 수정

`_scorePreviewFromModal` 체크를 `hasValidNext` 앞으로 이동하고, `_scorePreviewList` 기반으로 범위 확인:

```
// 수정 후
if (_scorePreviewFromModal) {
    // _scorePreviewIdx + dir 범위 확인 → navigateScorePreview()
} else {
    // 기존 sheetList[] 기반 hasValidNext 확인
}
```

## 테스트

- [ ] 찬양목록 → 악보 버튼 → 미리보기에서 좌우 스와이프로 이전/다음 악보 이동 확인
- [ ] 첫/마지막 악보에서 스와이프 → 스프링백 정상 작동 확인
- [ ] 콘티 악보 전체화면 스와이프 — 기존 동작 유지 확인

https://claude.ai/code/session_012XkYFFHp7cJ3cm3XbYayLV