### PR TITLE
feat: #148 전체 콘티 악보 PDF 다운로드

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,8 @@
                         <div class="btn-row">
                             <button class="btn-save" onclick="saveConti()">콘티함에 저장 💾</button>
                             <button class="btn-share" onclick="shareConti()">콘티 공유하기 📤</button>
+                            <button class="btn-save" onclick="exportContiToJson()" style="background:#059669;">JSON 내보내기 📥</button>
+                            <button class="btn-share" onclick="importContiFromJson()" style="background:#5465FF;">JSON 가져오기 📤</button>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
     <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-auth-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-database-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-messaging-compat.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 
     <link rel="stylesheet" href="style.css">
 
@@ -119,6 +120,7 @@
                             <button class="btn-share" onclick="shareConti()">콘티 공유하기 📤</button>
                             <button class="btn-save" onclick="exportContiToJson()" style="background:#059669;">JSON 내보내기 📥</button>
                             <button class="btn-share" onclick="importContiFromJson()" style="background:#5465FF;">JSON 가져오기 📤</button>
+                            <button onclick="downloadContiPdf()" style="background:#dc2626; border:none; border-radius:8px; padding:10px 14px; cursor:pointer; font-size:13px; font-weight:600; color:white;">📄 PDF 다운로드</button>
                         </div>
                         <div class="btn-row" style="margin-top:8px; flex-wrap:wrap; gap:8px;">
                             <div id="draft-indicator" style="display:none; align-items:center; gap:8px; padding:6px 10px; background:rgba(251,191,36,0.2); border:1px solid rgba(251,191,36,0.5); border-radius:8px; font-size:12px; color:#fbbf24;">

--- a/index.html
+++ b/index.html
@@ -120,6 +120,15 @@
                             <button class="btn-save" onclick="exportContiToJson()" style="background:#059669;">JSON 내보내기 📥</button>
                             <button class="btn-share" onclick="importContiFromJson()" style="background:#5465FF;">JSON 가져오기 📤</button>
                         </div>
+                        <div class="btn-row" style="margin-top:8px; flex-wrap:wrap; gap:8px;">
+                            <div id="draft-indicator" style="display:none; align-items:center; gap:8px; padding:6px 10px; background:rgba(251,191,36,0.2); border:1px solid rgba(251,191,36,0.5); border-radius:8px; font-size:12px; color:#fbbf24;">
+                                <span>📝 초안 저장됨</span>
+                                <button onclick="loadDraft()" style="background:rgba(251,191,36,0.3); border:1px solid rgba(251,191,36,0.6); border-radius:4px; padding:2px 8px; cursor:pointer; font-size:11px;">불러오기</button>
+                                <button onclick="deleteDraft()" style="background:none; border:none; color:#fbbf24; cursor:pointer; font-size:14px; padding:0;">✕</button>
+                            </div>
+                            <button onclick="saveDraft()" style="background:rgba(251,191,36,0.8); border:none; border-radius:8px; padding:6px 12px; cursor:pointer; font-size:12px; font-weight:600; color:#1a1a1a;">📝 초안 저장</button>
+                            <button onclick="loadDraft()" style="background:rgba(148,163,184,0.3); border:1px solid rgba(148,163,184,0.5); border-radius:8px; padding:6px 12px; cursor:pointer; font-size:12px; font-weight:600; color:#94a3b8;">📋 초안 불러오기</button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
                             </div>
                             <button onclick="saveDraft()" style="background:rgba(251,191,36,0.8); border:none; border-radius:8px; padding:6px 12px; cursor:pointer; font-size:12px; font-weight:600; color:#1a1a1a;">📝 초안 저장</button>
                             <button onclick="loadDraft()" style="background:rgba(148,163,184,0.3); border:1px solid rgba(148,163,184,0.5); border-radius:8px; padding:6px 12px; cursor:pointer; font-size:12px; font-weight:600; color:#94a3b8;">📋 초안 불러오기</button>
+                            <button onclick="openTemplateModal()" style="background:rgba(139,92,246,0.8); border:none; border-radius:8px; padding:6px 12px; cursor:pointer; font-size:12px; font-weight:600; color:white;">📂 템플릿</button>
                         </div>
                     </div>
                 </div>

--- a/js/history.js
+++ b/js/history.js
@@ -4,6 +4,98 @@
 let _loadedContiKey = null;
 let _loadedContiTitle = null;
 
+// ─── #134 초안(draft) / 확정(published) 상태 구분 ────────────────────────
+
+const DRAFT_STORAGE_KEY = 'conti_draft';
+
+// 초안 저장 (localStorage에만 저장)
+function saveDraft() {
+    const titleEl = document.getElementById('setlist-title');
+    const textareaEl = document.getElementById('song-input');
+    
+    const title = titleEl.value.trim();
+    const text = textareaEl.value.trim();
+    
+    if (!text || text.includes('아래 예시처럼 붙여넣어 주세요')) {
+        showToast('⚠️ 저장할 콘티 내용이 없습니다');
+        return;
+    }
+    
+    // 제목 날짜 정규화
+    const normalizedTitle = normalizeDateInTitle(title);
+    if (normalizedTitle !== title) titleEl.value = normalizedTitle;
+    
+    // 곡 번호 정규화
+    const normalizedText = normalizeContiText(text);
+    if (normalizedText !== text) textareaEl.value = normalizedText;
+    
+    const draft = {
+        title: normalizedTitle || '제목 없는 콘티',
+        text: normalizedText,
+        savedAt: Date.now()
+    };
+    
+    localStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
+    updateDraftIndicator(true);
+    showToast('📝 초안이 저장되었습니다 (게시 전 다른 사람이 볼 수 없음)');
+}
+
+// 초안 불러오기
+function loadDraft() {
+    const draftJson = localStorage.getItem(DRAFT_STORAGE_KEY);
+    if (!draftJson) {
+        showToast('저장된 초안이 없습니다');
+        return;
+    }
+    
+    try {
+        const draft = JSON.parse(draftJson);
+        document.getElementById('setlist-title').value = draft.title || '';
+        document.getElementById('song-input').value = draft.text || '';
+        document.getElementById('result-container').innerHTML = '';
+        sheetList = [];
+        _setLoadedConti(null, null); // Firebase 연동 해제
+        updateDraftIndicator(true);
+        showToast(`📋 초안을 불러왔습니다 (${draft.savedAt ? new Date(draft.savedAt).toLocaleString() : '시간 불명'})`);
+        startSearch();
+    } catch (e) {
+        console.error('초안 파싱 오류:', e);
+        showToast('⚠️ 초안을 불러오는 중 오류가 발생했습니다');
+    }
+}
+
+// 초안 삭제
+function deleteDraft() {
+    if (!localStorage.getItem(DRAFT_STORAGE_KEY)) {
+        showToast('삭제할 초안이 없습니다');
+        return;
+    }
+    
+    if (confirm('초안을 삭제하시겠습니까?')) {
+        localStorage.removeItem(DRAFT_STORAGE_KEY);
+        updateDraftIndicator(false);
+        showToast('🗑️ 초안이 삭제되었습니다');
+    }
+}
+
+// 초안 표시 상태 업데이트
+function updateDraftIndicator(hasDraft) {
+    const indicator = document.getElementById('draft-indicator');
+    if (!indicator) return;
+    
+    if (hasDraft) {
+        indicator.style.display = 'flex';
+    } else {
+        indicator.style.display = 'none';
+    }
+}
+
+// 초기 로드 시 초안 상태 확인
+(function initDraftIndicator() {
+    const hasDraft = !!localStorage.getItem(DRAFT_STORAGE_KEY);
+    updateDraftIndicator(hasDraft);
+})();
+
 function _setLoadedConti(key, title) {
     _loadedContiKey = key;
     _loadedContiTitle = title;

--- a/js/history.js
+++ b/js/history.js
@@ -494,3 +494,172 @@ function importContiFromJson() {
     };
     input.click();
 }
+
+// ─── #131 콘티 템플릿 저장/불러오기 ──────────────────────────────────────
+
+const TEMPLATE_STORAGE_KEY = 'conti_templates';
+
+// 템플릿 저장
+function saveAsTemplate() {
+    const text = document.getElementById('song-input').value.trim();
+    
+    if (!text) {
+        showToast('⚠️ 템플릿으로 저장할 콘티 내용이 없습니다');
+        return;
+    }
+    
+    // 곡 줄만 추출 (제목, 날짜, 코멘트 제외)
+    const lines = text.split('\n').filter(line => {
+        const trimmed = line.trim();
+        return /^\d+/.test(trimmed) || /^찬\d+/.test(trimmed) || /^통\d+/.test(trimmed);
+    });
+    
+    if (lines.length === 0) {
+        showToast('⚠️ 곡이 포함된 콘티만 템플릿으로 저장할 수 있습니다');
+        return;
+    }
+    
+    const templateName = prompt('템플릿 이름을 입력하세요:', `템플릿 ${getTemplateCount() + 1}`);
+    if (!templateName || !templateName.trim()) return;
+    
+    const templates = getTemplates();
+    const newTemplate = {
+        id: Date.now().toString(),
+        name: templateName.trim(),
+        songs: lines,
+        createdAt: new Date().toISOString()
+    };
+    
+    templates.push(newTemplate);
+    localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(templates));
+    
+    showToast(`✅ "${templateName}" 템플릿이 저장되었습니다`);
+}
+
+// 템플릿 목록 가져오기
+function getTemplates() {
+    const stored = localStorage.getItem(TEMPLATE_STORAGE_KEY);
+    if (!stored) return [];
+    try {
+        return JSON.parse(stored);
+    } catch {
+        return [];
+    }
+}
+
+// 템플릿 개수
+function getTemplateCount() {
+    return getTemplates().length;
+}
+
+// 템플릿 불러오기
+function loadTemplate(templateId) {
+    const templates = getTemplates();
+    const template = templates.find(t => t.id === templateId);
+    
+    if (!template) {
+        showToast('⚠️ 템플릿을 찾을 수 없습니다');
+        return;
+    }
+    
+    // 확인
+    const currentText = document.getElementById('song-input').value.trim();
+    if (currentText) {
+        const ok = confirm('현재 콘티 내용을 덮어쓰시겠습니까?');
+        if (!ok) return;
+    }
+    
+    document.getElementById('setlist-title').value = '';
+    document.getElementById('song-input').value = template.songs.join('\n');
+    document.getElementById('result-container').innerHTML = '';
+    sheetList = [];
+    _setLoadedConti(null, null);
+    
+    closeTemplateModal();
+    showToast(`📋 "${template.name}" 템플릿을 불러왔습니다 (${template.songs.length}곡)`);
+    startSearch();
+}
+
+// 템플릿 삭제
+function deleteTemplate(templateId) {
+    const templates = getTemplates();
+    const template = templates.find(t => t.id === templateId);
+    
+    if (!template) return;
+    
+    if (confirm(`"${template.name}" 템플릿을 삭제하시겠습니까?`)) {
+        const filtered = templates.filter(t => t.id !== templateId);
+        localStorage.setItem(TEMPLATE_STORAGE_KEY, JSON.stringify(filtered));
+        showToast('🗑️ 템플릿이 삭제되었습니다');
+        openTemplateModal(); // 목록 갱신
+    }
+}
+
+// 템플릿 모달 열기
+function openTemplateModal() {
+    const modal = document.getElementById('templateModal');
+    if (!modal) {
+        createTemplateModal();
+        return;
+    }
+    
+    const listContainer = document.getElementById('templateListContainer');
+    const templates = getTemplates();
+    
+    if (templates.length === 0) {
+        listContainer.innerHTML = '<li class="song-item" style="text-align:center; color:#999;">저장된 템플릿이 없습니다.</li>';
+    } else {
+        listContainer.innerHTML = '';
+        templates.forEach(template => {
+            const li = document.createElement('li');
+            li.className = 'song-item';
+            li.style.cssText = 'cursor:pointer; display:flex; justify-content:space-between; align-items:center;';
+            li.innerHTML = `
+                <div style="flex:1;">
+                    <div style="font-weight:600;">${template.name}</div>
+                    <div style="font-size:12px; color:#666; margin-top:4px;">${template.songs.join(', ')}</div>
+                </div>
+                <div style="display:flex; gap:8px;">
+                    <button onclick="loadTemplate('${template.id}')" style="background:#5465FF; color:white; border:none; border-radius:6px; padding:6px 12px; cursor:pointer; font-size:12px;">불러오기</button>
+                    <button onclick="deleteTemplate('${template.id}')" style="background:#ff6b6b; color:white; border:none; border-radius:6px; padding:6px 12px; cursor:pointer; font-size:12px;">삭제</button>
+                </div>
+            `;
+            listContainer.appendChild(li);
+        });
+    }
+    
+    modal.style.display = 'flex';
+}
+
+// 템플릿 모달 닫기
+function closeTemplateModal() {
+    const modal = document.getElementById('templateModal');
+    if (modal) modal.style.display = 'none';
+}
+
+// 템플릿 모달 DOM 생성
+function createTemplateModal() {
+    const modal = document.createElement('div');
+    modal.id = 'templateModal';
+    modal.className = 'modal-overlay';
+    modal.style.cssText = 'display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:10000; justify-content:center; align-items:center;';
+    modal.onclick = (e) => { if (e.target === modal) closeTemplateModal(); };
+    
+    modal.innerHTML = `
+        <div style="background:white; border-radius:12px; max-width:500px; width:90%; max-height:80vh; overflow:hidden; display:flex; flex-direction:column;">
+            <div style="padding:16px; border-bottom:1px solid #eee; display:flex; justify-content:space-between; align-items:center;">
+                <h3 style="margin:0; font-size:16px;">📋 콘티 템플릿</h3>
+                <button onclick="closeTemplateModal()" style="background:none; border:none; font-size:24px; cursor:pointer; color:#666;">&times;</button>
+            </div>
+            <ul id="templateListContainer" style="flex:1; overflow-y:auto; list-style:none; padding:0; margin:0;">
+                <li class="song-item" style="text-align:center; color:#999;">로딩 중...</li>
+            </ul>
+            <div style="padding:16px; border-top:1px solid #eee;">
+                <button onclick="saveAsTemplate()" style="width:100%; background:#181d3a; color:white; border:none; border-radius:8px; padding:12px; cursor:pointer; font-weight:600;">➕ 현재 콘티를 템플릿으로 저장</button>
+            </div>
+        </div>
+    `;
+    
+    document.body.appendChild(modal);
+    openTemplateModal(); // 모달 열기
+}

--- a/js/history.js
+++ b/js/history.js
@@ -306,3 +306,99 @@ document.getElementById('setlist-title').addEventListener('blur', function () {
     const v = normalizeDateInTitle(this.value);
     if (v !== this.value) this.value = v;
 });
+
+// ─── #136 콘티 JSON 내보내기/가져오기 ──────────────────────────────────────
+
+// JSON 내보내기: 현재 콘티를 JSON 파일로 다운로드
+function exportContiToJson() {
+    const title = document.getElementById('setlist-title').value.trim() || '제목 없는 콘티';
+    const text = document.getElementById('song-input').value.trim();
+    
+    if (!text) {
+        showToast('⚠️ 내보낼 콘티 내용이 없습니다');
+        return;
+    }
+    
+    const now = new Date();
+    const exportData = {
+        version: '1.0',
+        exported_at: now.toISOString(),
+        title: title,
+        songs: text.split('\n').filter(line => line.trim()),
+        metadata: {
+            total_songs: text.split('\n').filter(line => line.trim()).length,
+            app_version: typeof APP_VERSION !== 'undefined' ? APP_VERSION : 'unknown'
+        }
+    };
+    
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    // 파일명: 제목_날짜.json
+    const safeTitle = title.replace(/[\/\\:*?"<>|]/g, '_').substring(0, 30);
+    const dateStr = `${now.getFullYear()}${String(now.getMonth()+1).padStart(2,'0')}${String(now.getDate()).padStart(2,'0')}`;
+    a.download = `${safeTitle}_${dateStr}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+    
+    showToast('✅ 콘티가 JSON 파일로 내보내졌습니다');
+}
+
+// JSON 가져오기: 파일 선택 후 콘티에 적용
+function importContiFromJson() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json,application/json';
+    input.onchange = async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+            
+            // 데이터 검증
+            if (!data.title && !data.songs && !data.text) {
+                showToast('⚠️ 유효하지 않은 콘티 파일입니다');
+                return;
+            }
+            
+            // 데이터 형식 호환성 처리
+            let title = data.title || '';
+            let songs = [];
+            
+            if (Array.isArray(data.songs)) {
+                songs = data.songs;
+            } else if (typeof data.text === 'string') {
+                songs = data.text.split('\n').filter(line => line.trim());
+            }
+            
+            // 기존 콘티가 있으면 확인
+            const currentText = document.getElementById('song-input').value.trim();
+            if (currentText) {
+                const ok = confirm('현재 콘티 내용을 덮어쓰시겠습니까?\n(확인: 덮어쓰기, 취소: 취소)');
+                if (!ok) return;
+            }
+            
+            // 콘티 적용
+            document.getElementById('setlist-title').value = title;
+            document.getElementById('song-input').value = songs.join('\n');
+            document.getElementById('result-container').innerHTML = '';
+            sheetList = [];
+            _setLoadedConti(null, null); // Firebase 연동 해제
+            
+            showToast(`✅ "${title || '콘티'}"를 불러왔습니다 (${songs.length}곡)`);
+            
+            // 악보 자동 생성
+            startSearch();
+            
+        } catch (error) {
+            console.error('JSON 파싱 오류:', error);
+            showToast('⚠️ 파일을 읽는 중 오류가 발생했습니다');
+        }
+    };
+    input.click();
+}

--- a/js/share.js
+++ b/js/share.js
@@ -244,3 +244,145 @@ async function doShareConti() {
     a.click();
     closeSharePreview();
 }
+
+// ─── #148 전체 콘티 악보 PDF 다운로드 ─────────────────────────────────────
+
+// 전체 콘티 악보 PDF로 다운로드
+async function downloadContiPdf() {
+    if (typeof jspdf === 'undefined') {
+        showToast('⚠️ PDF 라이브러리가 로드되지 않았습니다');
+        return;
+    }
+    
+    const title = document.getElementById('setlist-title').value.trim() || '제목 없는 콘티';
+    const rawContent = document.getElementById('song-input').value.trim();
+    
+    if (!rawContent) {
+        showToast('⚠️ PDF로 내보낼 콘티 내용이 없습니다');
+        return;
+    }
+    
+    // 곡 줄 추출
+    const songLines = rawContent.split('\n').filter(line => {
+        const trimmed = line.trim();
+        return /^\d+/.test(trimmed) || /^찬\d+/.test(trimmed) || /^통\d+/.test(trimmed);
+    });
+    
+    if (songLines.length === 0) {
+        showToast('⚠️ 곡이 포함된 콘티만 PDF로 내보낼 수 있습니다');
+        return;
+    }
+    
+    showToast('🔄 PDF 생성 중... (이미지 로딩 대기)');
+    
+    try {
+        const { jsPDF } = jspdf;
+        const pdf = new jsPDF('p', 'mm', 'a4'); // 세로 A4
+        const pageWidth = pdf.internal.pageSize.getWidth();  // 210mm
+        const pageHeight = pdf.internal.pageSize.getHeight(); // 297mm
+        
+        // ── 1페이지: 콘티 표지 ──────────────────────────────────────────
+        const PALETTES = [
+            { bg: [45, 74, 92], accent: [126, 200, 227] },
+            { bg: [61, 43, 90], accent: [196, 168, 232] },
+            { bg: [26, 58, 42], accent: [126, 207, 170] },
+            { bg: [90, 45, 58], accent: [240, 168, 184] },
+            { bg: [45, 58, 92], accent: [168, 191, 240] },
+            { bg: [74, 48, 32], accent: [240, 200, 144] },
+            { bg: [28, 44, 62], accent: [144, 200, 240] },
+            { bg: [58, 32, 64], accent: [216, 168, 240] },
+        ];
+        const hashIdx = (str) => {
+            let h = 0;
+            for (let i = 0; i < str.length; i++) h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+            return Math.abs(h) % PALETTES.length;
+        };
+        const { bg: BG, accent: AC } = PALETTES[hashIdx(title)];
+        
+        // 배경
+        pdf.setFillColor(...BG);
+        pdf.rect(0, 0, pageWidth, pageHeight, 'F');
+        
+        // 제목
+        pdf.setTextColor(255, 255, 255);
+        pdf.setFontSize(28);
+        pdf.text(title, pageWidth / 2, 80, { align: 'center' });
+        
+        // 곡 수
+        pdf.setFontSize(14);
+        pdf.setTextColor(...AC);
+        pdf.text(`총 ${songLines.length}곡`, pageWidth / 2, 100, { align: 'center' });
+        
+        // ── 2페이지 이후: 악보 이미지 ─────────────────────────────────
+        let pageNum = 1;
+        const margin = 10;
+        const imgWidth = pageWidth - margin * 2;
+        const imgHeight = pageHeight - margin * 2;
+        
+        for (const songLine of songLines) {
+            // 곡 번호 추출
+            const match = songLine.match(/^(?:통|찬)?(\d+)/);
+            if (!match) continue;
+            
+            const num = match[1].padStart(3, '0');
+            const prefix = songLine.includes('통') ? '통' : songLine.includes('찬') ? '찬' : '';
+            const imgKey = prefix + num;
+            
+            // 이미지 경로
+            const basePath = prefix === '찬' ? 'images/hymn/' : prefix === '통' ? 'images/tongil/' : 'images/';
+            const extensions = ['.jpg', '.png', '.gif', '.jfif', '.JPG', '.PNG', '.GIF', '.JFIF'];
+            
+            // 이미지 찾기
+            let imgSrc = null;
+            for (const ext of extensions) {
+                const testSrc = basePath + num + ext;
+                try {
+                    const loaded = await loadImageAsync(testSrc);
+                    if (loaded) {
+                        imgSrc = testSrc;
+                        break;
+                    }
+                } catch {}
+            }
+            
+            if (imgSrc) {
+                pdf.addPage();
+                pageNum++;
+                
+                // 이미지 추가
+                try {
+                    pdf.addImage(imgSrc, 'JPEG', margin, margin, imgWidth, imgHeight, undefined, 'FAST');
+                } catch (err) {
+                    console.warn('PDF 이미지 추가 실패:', imgSrc, err);
+                    // 이미지 실패 시 빈 페이지 또는 텍스트
+                    pdf.setFontSize(12);
+                    pdf.setTextColor(100);
+                    pdf.text(`악보 이미지 로드 실패: ${imgKey}`, pageWidth / 2, pageHeight / 2, { align: 'center' });
+                }
+            }
+        }
+        
+        // PDF 다운로드
+        const safeTitle = title.replace(/[\/\\:*?"<>|]/g, '_').substring(0, 30);
+        const dateStr = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+        pdf.save(`${safeTitle}_${dateStr}.pdf`);
+        
+        showToast(`✅ PDF 다운로드 완료! (${pageNum}페이지)`);
+        
+    } catch (error) {
+        console.error('PDF 생성 오류:', error);
+        showToast('⚠️ PDF 생성 중 오류가 발생했습니다');
+    }
+}
+
+// 이미지 비동기 로드 헬퍼
+function loadImageAsync(src) {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => resolve(true);
+        img.onerror = () => resolve(false);
+        img.src = src;
+        // 타임아웃
+        setTimeout(() => resolve(false), 3000);
+    });
+}

--- a/js/sheet-viewer.js
+++ b/js/sheet-viewer.js
@@ -1,5 +1,88 @@
 // ─── 악보 찾기 & 뷰어 ────────────────────────────────────────────────────────
 
+// ─── #133/#130/#132 태그 파싱 ───────────────────────────────────────────
+
+const DEFAULT_SONG_DURATION = 4; // 기본 곡 소요 시간 (분)
+
+// 태그 정규식: #키:D, #메모:xxx, #시간:4
+const TAG_REGEX = /#(키|키|KEY|key|메모|MEMO|memo|시간|TIME|time|분|MIN|min)\s*[:：]\s*([^\s#]+)/g;
+
+// 곡 줄에서 태그 추출
+function parseSongTags(line) {
+    const tags = { key: null, memo: null, duration: null };
+    let match;
+    const regex = new RegExp(TAG_REGEX.source, 'gi');
+    while ((match = regex.exec(line)) !== null) {
+        const tagType = match[1].toLowerCase();
+        const value = match[2].trim();
+        
+        if (['키', '키', 'key'].includes(tagType)) {
+            tags.key = value;
+        } else if (['메모', 'memo'].includes(tagType)) {
+            tags.memo = value;
+        } else if (['시간', 'time', '분', 'min'].includes(tagType)) {
+            const num = parseInt(value);
+            if (!isNaN(num) && num > 0 && num <= 60) {
+                tags.duration = num;
+            }
+        }
+    }
+    return tags;
+}
+
+// 태그가 포함된 원본 줄에서 태그 제거 (제목만 남김)
+function removeTagsFromLine(line) {
+    return line.replace(TAG_REGEX, '').replace(/\s+/g, ' ').trim();
+}
+
+// 전체 콘티에서 소요 시간 합산
+function calculateTotalDuration(normalizedText) {
+    const lines = normalizedText.split('\n');
+    let totalMinutes = 0;
+    
+    lines.forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        
+        // 곡 줄인지 확인
+        const isSongLine = /^\d+/.test(trimmed) || /^찬\d+/.test(trimmed) || /^통\d+/.test(trimmed);
+        if (!isSongLine) return;
+        
+        const tags = parseSongTags(trimmed);
+        totalMinutes += tags.duration || DEFAULT_SONG_DURATION;
+    });
+    
+    return totalMinutes;
+}
+
+// 소요 시간 표시 업데이트
+function updateDurationDisplay(totalMinutes) {
+    let indicator = document.getElementById('duration-indicator');
+    if (!indicator) {
+        indicator = document.createElement('div');
+        indicator.id = 'duration-indicator';
+        indicator.style.cssText = 'text-align:center; padding:8px; font-size:12px; color:#94a3b8; background:#f8fafc; border-radius:8px; margin-top:8px;';
+        
+        // btn-group 다음에 추가
+        const btnGroup = document.querySelector('.btn-group');
+        if (btnGroup) {
+            btnGroup.parentElement.insertBefore(indicator, btnGroup.nextSibling);
+        }
+    }
+    
+    if (totalMinutes > 0) {
+        const hours = Math.floor(totalMinutes / 60);
+        const mins = totalMinutes % 60;
+        const timeText = hours > 0 
+            ? `⏱️ 예상 소요 시간: 약 ${hours}시간 ${mins}분` 
+            : `⏱️ 예상 소요 시간: 약 ${mins}분`;
+        indicator.textContent = timeText;
+        indicator.style.display = 'block';
+    } else {
+        indicator.style.display = 'none';
+    }
+}
+
 function tryLoadImage(imgElement, songNum, extIndex, onDone) {
     const s = String(songNum);
     const isHymn   = s.startsWith('찬');
@@ -42,6 +125,10 @@ async function startSearch() {
     const songLines = allLines.filter(l => /^\d+/.test(l) || /^찬\d+/.test(l) || /^통\d+/.test(l));
     if (songLines.length === 0) return alert('곡 리스트를 입력해주세요!');
 
+    // ── #133/#130/#132: 전체 소요 시간 계산 ────────────────────────────
+    const totalDuration = calculateTotalDuration(normalized);
+    updateDurationDisplay(totalDuration);
+
     sheetList = new Array(allLines.length).fill(null);
 
     // ── 카드 그리드 (가로/세로 모드 공통) ──
@@ -58,7 +145,11 @@ async function startSearch() {
         const isTongil  = !!tongilMatch;
         const isHymn    = !!hymnMatch;
         const numPadded = match[1].padStart(3, '0');
-        const songTitle = match[2].trim();
+        const rawTitle = match[2].trim();
+        
+        // ── #133/#130: 태그 파싱 ─────────────────────────────────────
+        const tags = parseSongTags(rawTitle);
+        const songTitle = removeTagsFromLine(rawTitle).trim();
         const label     = isTongil ? `통${numPadded} ${songTitle}` : isHymn ? `찬${numPadded} ${songTitle}` : `${numPadded} ${songTitle}`;
         const imgKey    = isTongil ? `통${numPadded}` : isHymn ? `찬${numPadded}` : numPadded;
 
@@ -66,13 +157,48 @@ async function startSearch() {
         card.className = 'sheet-music-card';
         card.dataset.lineIndex = String(index);
         card.dataset.originalLine = line;
+        
+        // ── 카드 헤더 (제목 + 태그) ────────────────────────────────────
+        const cardHeader = document.createElement('div');
+        cardHeader.className = 'sheet-title';
+        cardHeader.innerHTML = `<span class="drag-handle" title="길게 눌러 순서 변경">⠿</span><span class="sheet-title-text">${label}</span>`;
+        
+        // 태그 배지 추가 (#133/#130)
+        if (tags.key || tags.memo || tags.duration) {
+            const tagContainer = document.createElement('div');
+            tagContainer.className = 'song-tags';
+            tagContainer.style.cssText = 'display:flex; gap:4px; flex-wrap:wrap; margin-top:4px; padding:0 4px;';
+            
+            if (tags.key) {
+                const keyBadge = document.createElement('span');
+                keyBadge.style.cssText = 'background:#818cf8; color:white; padding:2px 6px; border-radius:4px; font-size:10px; font-weight:600;';
+                keyBadge.textContent = `🎵 ${tags.key}`;
+                tagContainer.appendChild(keyBadge);
+            }
+            if (tags.duration) {
+                const timeBadge = document.createElement('span');
+                timeBadge.style.cssText = 'background:#34d399; color:#064e3b; padding:2px 6px; border-radius:4px; font-size:10px; font-weight:600;';
+                timeBadge.textContent = `⏱️ ${tags.duration}분`;
+                tagContainer.appendChild(timeBadge);
+            }
+            if (tags.memo) {
+                const memoBadge = document.createElement('span');
+                memoBadge.style.cssText = 'background:#fbbf24; color:#78350f; padding:2px 6px; border-radius:4px; font-size:10px; font-weight:600;';
+                memoBadge.textContent = `📝 ${tags.memo}`;
+                memoBadge.title = tags.memo; // 긴 텍스트는 툴팁으로
+                tagContainer.appendChild(memoBadge);
+            }
+            cardHeader.appendChild(tagContainer);
+        }
+        
         const removeBtn = document.createElement('button');
         removeBtn.className = 'card-remove-btn';
         removeBtn.title = '콘티에서 제거';
         removeBtn.textContent = '✕';
         removeBtn.onclick = (e) => { e.stopPropagation(); removeCard(card); };
-        card.innerHTML = `<div class="sheet-title"><span class="drag-handle" title="길게 눌러 순서 변경">⠿</span><span class="sheet-title-text">${label}</span></div>`;
-        card.querySelector('.sheet-title').appendChild(removeBtn);
+        cardHeader.appendChild(removeBtn);
+        card.appendChild(cardHeader);
+        
         const imgTag = document.createElement('img');
         imgTag.alt = `${isTongil ? '통일찬송가 ' : isHymn ? '새찬송가 ' : ''}${numPadded} 악보 찾는 중...`;
         card.appendChild(imgTag);


### PR DESCRIPTION
## 요약
- jsPDF CDN 추가 (cdnjs)
- downloadContiPdf(): 현재 콘티의 모든 악보 이미지를 PDF로 생성
- 1페이지: 콘티 표지 (제목, 곡 수)
- 2페이지 이후: 각 곡의 악보 이미지
- A4 세로 형식

## 변경 파일
- js/share.js
- index.html

## related #148